### PR TITLE
fix: no pointer events once add field modal was closed on /admin/form…

### DIFF
--- a/src/app/admin/forms/add/page.tsx
+++ b/src/app/admin/forms/add/page.tsx
@@ -326,7 +326,7 @@ const AddFormPage = () => {
                                     })}
                                 </div>
 
-                                <DropdownMenu>
+                                <DropdownMenu modal={false}>
                                     <DropdownMenuTrigger asChild>
                                         <Button className="px-8 mt-4">
                                             <PlusIcon />


### PR DESCRIPTION
…s/add

This was an issue with shadcn and is open here: https://github.com/shadcn-ui/ui/issues/1859.